### PR TITLE
Add support for 'x' for LocalWorker

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,3 +15,4 @@ Release 0.0.0 (Development)
 * Fixed support for ``follow_symlinks`` in :meth:`artisan.BaseWorker.change_file_owner`,
   :meth:`artisan.BaseWorker.change_file_group, and :meth:`artisan.BaseWorker.change_file_mode`.
   (`PR #58 <https://github.com/SethMichaelLarson/artisan/pull/58>`_)
+* Added support for exclusive file opening via ``open_file(path, mode='x')`` for BaseWorker. (`PR #71 <https://github.com/SethMichaelLarson/artisan/pull/71>`_)

--- a/artisan/compat.py
+++ b/artisan/compat.py
@@ -22,8 +22,8 @@ __all__ = [
 ]
 
 # Python version checking.
-PY2 = sys.version_info == 2
-PY3 = sys.version_info == 3
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
 PY33 = sys.version_info >= (3, 3)
 PY34 = sys.version_info >= (3, 4)
 PY35 = sys.version_info >= (3, 5)

--- a/artisan/worker/local_worker.py
+++ b/artisan/worker/local_worker.py
@@ -7,7 +7,7 @@ import stat
 from .command import LocalCommand
 from .base_worker import BaseWorker
 from .file_attrs import stat_to_file_attrs
-from ..compat import PY33, follows_symlinks
+from ..compat import PY2, PY33, follows_symlinks
 from ..exceptions import OperationNotSupported
 
 
@@ -100,7 +100,12 @@ class LocalWorker(BaseWorker):
         return stat.S_ISLNK(os.lstat(path).st_mode)
 
     def open_file(self, path, mode='r'):
-        return open(self._normalize_path(path), mode)
+        # Python 2.x doesn't support the mode='x' flag.
+        path = self._normalize_path(path)
+        if PY2 and mode == 'x':
+            os.open(path, os.O_CREAT | os.O_EXCL)
+            mode = 'w'
+        return open(path, mode)
 
     def remove_file(self, path):
         os.remove(self._normalize_path(path))

--- a/docs/source/api_reference/command.rst
+++ b/docs/source/api_reference/command.rst
@@ -1,12 +1,12 @@
 Commands
 ========
 
-.. autoclass:: artisan.BaseCommand
+.. autoclass:: artisan.worker.BaseCommand
 
 Example Usage
 -------------
 
-Here is an example usage of a :class:`artisan.BaseCommand` object.
+Here is an example usage of a :class:`artisan.worker.BaseCommand` object.
 
 .. code-block:: python
 

--- a/docs/source/api_reference/worker.rst
+++ b/docs/source/api_reference/worker.rst
@@ -1,16 +1,16 @@
 Workers
 =======
 
-.. autoclass:: artisan.BaseWorker
+.. autoclass:: artisan.worker.BaseWorker
 
 Implementations
 ---------------
 
-These are the :class:`artisan.BaseWorker` implementations that
+These are the :class:`artisan.worker.BaseWorker` implementations that
 are provided by default by the Artisan module.
 
-.. autoclass:: artisan.LocalWorker
+.. autoclass:: artisan.worker.LocalWorker
 
-.. autoclass:: artisan.SshWorker
+.. autoclass:: artisan.worker.SshWorker
 
-.. autoclass:: artisan.RemoteWorker
+.. autoclass:: artisan.worker.RemoteWorker


### PR DESCRIPTION
#### Changes Proposed by this Pull Request:

Exclusive file mode for `artisan.worker.LocalWorker`.

```python
from artisan.worker import LocalWorker

w = LocalWorker()
with w.open_file('excl', mode='x') as f:
    f.write('This file was just created!')
```

#### TO-DO Checklist:

- [x] Fixes Issue #: #60 
- [x] I believe that this code is well written.
- [x] Tests for this Pull Request have been written.
- [x] `CHANGELOG.rst` updated.
- [ ] `CONTRIBUTORS.rst` updated.
